### PR TITLE
Option to skip missing check if tag is empty in source and missing in comparison xml

### DIFF
--- a/lib/model/options-model.ts
+++ b/lib/model/options-model.ts
@@ -1,3 +1,4 @@
 export interface IOptionsModel {
   compareElementValues: boolean
+  skipMissingTagIfValueNull: boolean
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diff-js-xml",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4699,6 +4699,31 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "test:watch": "npm run test -- --watch --watch-extensions ts",
     "cover": "nyc --reporter=lcov --reporter=text npm run test",
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "lint": "tslint -t stylish --project  \"tsconfig.json\"",
     "lint:fix": "npm run lint -- --fix",
     "build": "npm run clean && tsc -p tsconfig.production.json",
@@ -55,6 +55,7 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-microsoft-contrib": "^5.2.1",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.1.6",
+    "rimraf": "~3.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ const compareObjects = (
           } 
 
           if (!valueB && (valueA !== undefined && JSON.stringify((<any>a)[key], null, 1) !== '{}') && options.skipMissingTagIfValueNull) {
-            console.log(valueB, valueA);
             const diffResult: IDiffResultModel = {
               path: formattedKey,
               resultType: "missing element",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -103,7 +103,7 @@ describe("when schema with skip element is provided that is not in rhs xml", () 
 })
 
 describe("when comparing two different xml element values with compareElementValues false", () => {
-  const optionsNoValueCompare = { compareElementValues: false }
+  const optionsNoValueCompare = { compareElementValues: false, skipMissingTagIfValueNull: false }
 
   const lhsxml: string =
     '<string-array name="languages_array"><item>English2</item><item>Chinese</item><item>French</item><item>Spanish</item></string-array>'
@@ -195,3 +195,88 @@ describe("when comparing two identical xml strings that have declarations", () =
     )
   })
 })
+
+describe("when skipping lhsNullTags", () => {
+  const options = { skipMissingTagIfValueNull: true, compareElementValues: true };
+
+  it("no differences are reported", () => {
+    let lhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item /><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let rhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let result: IDiffResultModel[] = []
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      options,
+      (dff: IDiffResultModel[]) => {
+        result = dff
+      }
+    )
+    result.length.should.equal(0)
+  })
+
+  it("one difference is reported.", () => {
+    let lhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item /><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let rhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item>Michael Scott</item><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let result: IDiffResultModel[] = []
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      options,
+      (dff: IDiffResultModel[]) => {
+        result = dff
+      }
+    )
+    result.length.should.equal(1)
+    result[0].path.should.equal('root.item');
+    result[0].resultType.should.equal('difference in element value')
+  })
+
+  it("one difference is reported-2.", () => {
+    let lhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let rhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item>Michael Scott</item><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let result: IDiffResultModel[] = []
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      options,
+      (dff: IDiffResultModel[]) => {
+        result = dff
+      }
+    )
+    result.length.should.equal(1)
+    result[0].path.should.equal('root.item');
+    result[0].resultType.should.equal('missing element')
+  })
+
+  it("two differences are reported.", () => {
+    let lhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item>Michael Scott</item><item2 /><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let rhsxml: string =
+      '<?xml version="1.0" encoding="UTF-8"?><root><item2>Scranton</item2><item3>Ohio</item3><item4>Dunder Miflin</item4></root>'
+    let result: IDiffResultModel[] = []
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      options,
+      (dff: IDiffResultModel[]) => {
+        result = dff
+      }
+    )
+    result.length.should.equal(2)
+    result[0].path.should.equal('root.item');
+    result[0].resultType.should.equal('missing element')
+    result[1].path.should.equal('root.item2')
+    result[1].resultType.should.equal('difference in element value')
+  })
+})
+


### PR DESCRIPTION
For example if left compare is
`<root>
    <item />
     <item2>
            Michael Scott
      </item2>
  </root>`
and right compare is
`<root>
     <item2>
            Michael Scott
      </item2>
  </root>`

You now can have the option for the library to not throw a 'missing element' validation.