### PR TITLE
Passthrough xml-js options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ const schema = { elementA: { skipKey:true}}
 
 **options** generic options or null if not needed current options available:
 - **compareElementValues** to disable comparing of element values default is true
+- **xml2jsOptions** pass through options to xml-js. xml-js has its own default options, and we override a handful: 
+`compact: true, ignoreDoctype: true, ignoreDeclaration: true, ignoreAttributes: true`
+You can override these, or others, but most option combinations have not been tested carefully so use caution.
 
 ```javascript
 const options = {compareElementValues: false}

--- a/lib/model/options-model.ts
+++ b/lib/model/options-model.ts
@@ -1,3 +1,4 @@
 export interface IOptionsModel {
-  compareElementValues: boolean
+  compareElementValues?: boolean
+  xml2jsOptions?: any
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -195,3 +195,138 @@ describe("when comparing two identical xml strings that have declarations", () =
     )
   })
 })
+
+describe("when comparing two identical xml strings with only leading/trailing whitespace differences", () => {
+  const lhsxml: string = `<root-elem><item1>
+Leading and Trailing Line Break
+</item1><item2>   Some Leading and Trailing Space   </item2></root-elem>`
+
+  const rhsxml: string = `<root-elem><item1>Leading and Trailing Line Break</item1><item2>Some Leading and Trailing Space</item2></root-elem>`
+
+  it("should return an array of two differences by default", () => {
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      undefined,
+      (result: IDiffResultModel[]) => {
+        result.length.should.equal(2)
+      }
+    )
+  })
+
+  it("no differences are reported if trim xml2js option is set", () => {
+    const xml2jsOpts = {
+      xml2jsOptions: {
+        trim: true
+      }
+    }
+
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      xml2jsOpts,
+      (result: IDiffResultModel[]) => {
+        result.length.should.equal(0)
+      }
+    )
+  })
+})
+
+describe("when comparing two numeric strings with different precision", () => {
+  const lhsxml: string = `<root-elem><item1 foo="bar">1.2</item1><item2>1.2</item2><somearray><arrayitem>1.2</arrayitem><arrayitem>1.2</arrayitem><arrayitem>1.2</arrayitem></somearray></root-elem>`
+  const rhsxml: string = `<root-elem><item1 foo="bar">1.20</item1><item2>1.20</item2><somearray><arrayitem>1.2</arrayitem><arrayitem>1.20</arrayitem><arrayitem>1.2</arrayitem></somearray></root-elem>`
+
+  it("should return an array of two differences by default", () => {
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      undefined,
+      (result: IDiffResultModel[]) => {
+        result.length.should.equal(3)
+      }
+    )
+  })
+
+  it("no differences are reported if nativeType xml2js option is set", () => {
+    const xml2jsOpts = {
+      xml2jsOptions: {
+        nativeType: true
+      }
+    }
+
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      xml2jsOpts,
+      (result: IDiffResultModel[]) => {
+        result.length.should.equal(0)
+      }
+    )
+  })
+})
+
+describe("when removing _text keys from comparison strings", () => {
+  const lhsxml: string = `<root-elem><item1 foo="bar">1.2</item1><item2>2.3</item2><item3>3.0</item3></root-elem>`
+  const rhsxml: string = `<root-elem><item1 foo="baz">1.23</item1><item2>2.34</item2><item3>3</item3></root-elem>`
+
+  it("should remove the _text key when attributes are ignored", () => {
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      { xml2jsOptions: { ignoreAttributes: true } },
+      (result: IDiffResultModel[]) => {
+        JSON.stringify(result).should.not.contain("_text")
+        result.length.should.equal(3)
+      }
+    )
+  })
+
+  it("should remove the _text key when attributes are ignored and native values are parsed", () => {
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      { xml2jsOptions: { ignoreAttributes: true, nativeType: true } },
+      (result: IDiffResultModel[]) => {
+        JSON.stringify(result).should.not.contain("_text")
+        result.length.should.equal(2)
+      }
+    )
+  })
+
+  it("should not remove the _text key for nodes with attribute changes", () => {
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      { xml2jsOptions: { ignoreAttributes: false } },
+      (result: IDiffResultModel[]) => {
+        result.length.should.equal(4)
+        JSON.stringify(result[0]).should.contain("_attributes")
+        JSON.stringify(result[1]).should.contain("_text")
+        JSON.stringify(result[2]).should.not.contain("_text")
+        JSON.stringify(result[3]).should.not.contain("_text")
+      }
+    )
+  })
+
+  it("should remove the _text key when attributes are ignored and native values are parsed", () => {
+    tool.diffAsXml(
+      lhsxml,
+      rhsxml,
+      undefined,
+      { xml2jsOptions: { ignoreAttributes: false, nativeType: true } },
+      (result: IDiffResultModel[]) => {
+        result.length.should.equal(3)
+        JSON.stringify(result[0]).should.contain("_attributes")
+        JSON.stringify(result[1]).should.contain("_text")
+        JSON.stringify(result[2]).should.not.contain("_text")
+      }
+    )
+  })
+})


### PR DESCRIPTION
Thank you for this library, it got us 90% of the way to the finish line. I just needed to adjust some of the default xml-js options for our use case, specifically we needed `nativeType: true, trim: true, ignoreAttributes: false`

To make this more generally useful, I just changed the code to allow any xml-js option to be passed through. So, I'm submitting this PR in case you want to merge it in.

The `nativeType: true` change meant the regex to remove _text keys also needed some adjustment.

I've tested with those settings and all works as expected. This change should not cause any backward incompatibilities because all default settings remain the same, all tests pass, and no changes were made to existing tests.


