### PR TITLE
Adjust package files to support typescript projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "typings": "dist/src/index",
   "files": [
     "lib/**/*",
-    "dist/src/index.js",
-    "dist/src/index.d.ts"
+    "dist/**/*"
   ],
   "scripts": {
     "test": "mocha -r ts-node/register test/**/*.test.ts",


### PR DESCRIPTION
Fix for issue #7.

Looks like `dist/lib` was being left out during package install, which `src/index.d.ts` depends on. 